### PR TITLE
increased top padding to match main header

### DIFF
--- a/website/client/components/snackbars/notifications.vue
+++ b/website/client/components/snackbars/notifications.vue
@@ -8,7 +8,7 @@
   .notifications {
     position: fixed;
     right: 10px;
-    top: 10px;
+    top: 65px;
     width: 350px;
     z-index: 99999;
   }


### PR DESCRIPTION
[//]: # 
Fixes https://github.com/HabitRPG/habitica/issues/9678

### Changes
[//]: # Adjusted the top padding of the snackbar notification to be higher than the main header so the two doesn't overlap. The header is set at 56px and the old snackbar was set at 10px, now it's set to 65px. This gives the two elements some space and avoids the overlap. (main header is nav.navbar[data-v-f18a1cd2] from ./website/client/components/header/menu.vue)



[//]: # (Put User ID in here - found on the Habitica website at User Icon > Settings > API)

----
UUID: 5e7df578-43e2-43aa-ac2e-8ed10d8f2fd5
